### PR TITLE
202404

### DIFF
--- a/golang/tline/go.mod
+++ b/golang/tline/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdouchement/tline
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dustin/go-humanize v1.0.1
@@ -10,9 +10,9 @@ require (
 )
 
 require (
-	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	golang.org/x/sys v0.19.0 // indirect
 )

--- a/golang/tline/go.sum
+++ b/golang/tline/go.sum
@@ -4,6 +4,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
+github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -19,9 +21,14 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
+github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/readme/extrarc.md
+++ b/readme/extrarc.md
@@ -17,7 +17,7 @@ $ cd workerpool/
 $ acd workerpool/
 ```
 
-- `exa` a modern version of ‘ls’.
+- `exa` a modern version of 'ls'.
 
 https://github.com/ogham/exa
 
@@ -30,7 +30,20 @@ alias ll="exa -al --group-directories-first"
 https://github.com/BurntSushi/ripgrep
 
 ```sh
-alias rg='rg -g "!*GODOC.md" -g "!/vendor/"'
+alias rg='rg -g "!*GODOC.md" -g "!/vendor/" -g "!/node_modules/"'
+```
+
+- Archiver
+
+```sh
+alias arca='arc archive'
+alias arcu='arc unarchive'
+```
+
+- Yaegi
+
+```sh
+alias yaegi='rlwrap yaegi'
 ```
 
 - Use Hombrew `curl`
@@ -102,5 +115,30 @@ alias nodejs=node
 ```sh
 function mem-usage() {
   ps -eo size,pid,user,command --sort -size | awk '{ hr=$1/1024 ; printf("%13.2f Mb ",hr) } { for ( x=4 ; x<=NF ; x++ ) { printf("%s ",$x) } print "" }'
+}
+```
+
+- Golang
+
+```sh
+go build -ldflags "-s -w" -o ~/bin/$(basename $(pwd)) .
+```
+
+```sh
+function gofinn() {
+  (
+    set -x
+    GOOS=linux go build -ldflags "-s -w" -o $1 $2
+    finn $1
+    rm $1
+  )
+}
+```
+
+- cURL + TLS check
+
+```sh
+curt () {
+	curl --insecure -v $@ 2>&1 | awk 'BEGIN { cert=0 } /^\* SSL connection/ { cert=1 } /^\*/ { if (cert) print }'
 }
 ```

--- a/readme/vscode.md
+++ b/readme/vscode.md
@@ -1,0 +1,89 @@
+# VSCode
+
+Extensions:
+
+- Name: Go\
+  Id: golang.go\
+  Description: Rich Go language support for Visual Studio Code\
+  Version: 0.41.4\
+  Publisher: golang\
+  VS Marketplace Link: https://open-vsx.org/vscode/item?itemName=golang.Go`
+
+- Name: EditorConfig for VS Code\
+  Id: EditorConfig.EditorConfig\
+  Description: EditorConfig Support for Visual Studio Code\
+  Version: 0.15.1\
+  Publisher: EditorConfig
+
+- Name: vscode-base64\
+  Id: adamhartford.vscode-base64\
+  Description: Base64 encode/decode the current selections.\
+  Version: 0.1.0\
+  Publisher: adamhartford\
+  VS Marketplace Link: https://open-vsx.org/vscode/item?itemName=adamhartford.vscode-base64
+
+- Name: file-icons\
+  Id: file-icons.file-icons\
+  Description: File-specific icons in VSCode for improved visual grepping.\
+  Version: 1.1.0\
+  Publisher: File Icons\
+  VS Marketplace Link: https://open-vsx.org/vscode/item?itemName=file-icons.file-icons
+
+- Name: Prettify JSON\
+  Id: mohsen1.prettify-json\
+  Description: Visual Studio Code Prettify JSON Extension\
+  Version: 0.0.3\
+  Publisher: Mohsen Azimi
+
+- Name: Todo Tree\
+  Id: Gruntfuggly.todo-tree\
+  Description: Show TODO, FIXME, etc. comment tags in a tree view\
+  Version: 0.0.215\
+  Publisher: Gruntfuggly\
+  VS Marketplace Link: https://open-vsx.org/vscode/item?itemName=Gruntfuggly.todo-tree
+
+Settings:
+
+`user/settings.json`
+
+```json
+{
+    "explorer.autoReveal": false,
+    "files.trimTrailingWhitespace": true,
+    "go.lintTool": "revive",
+    "git.openRepositoryInParentFolders": "never",
+    "files.associations": {
+        "*.tgo": "tengo"
+    },
+    "go.coverOnTestPackage": false,
+    "go.editorContextMenuCommands": {
+        "testAtCursor": false,
+        "generateTestForFunction": false,
+        "testCoverage": false,
+        "playground": false,
+        "debugTestAtCursor": false
+    },
+    "go.playground": {
+        "openbrowser": false,
+        "share": false,
+        "run": false
+    },
+    "go.showWelcome": false,
+    "go.survey.prompt": false,
+    "go.formatTool": "gofumpt",
+    "workbench.startupEditor": "none",
+    "todohighlight.defaultStyle": {},
+    "todo-tree.highlights.useColourScheme": true,
+    "todo-tree.highlights.backgroundColourScheme": [
+        "red",
+        "C71585",
+        "FF8C00",
+        "lime",
+        "blue",
+        "indigo",
+        "violet"
+    ],
+    "todo-tree.regex.regex": "(//|--|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.)).*[^\\w]($TAGS)([^\\p{L}]|$)",
+    "editor.fontFamily": "Source Code Pro for Powerline"
+}
+```

--- a/runcom/gorc
+++ b/runcom/gorc
@@ -2,4 +2,3 @@ export DEP_GOPATH="${HOME}/.gopath"
 export DEV_GOPATH="${HOME}/workspaces/golang"
 export GOPATH="${DEP_GOPATH}:${DEV_GOPATH}"
 export PATH=${PATH}:${GOROOT}/bin:${DEP_GOPATH}/bin:${DEV_GOPATH}/bin
-alias atom='GOROOT=$(go env GOROOT) atom'


### PR DESCRIPTION
- [x] NerdFont Source Code Pro & Intel One Mono

- [x] Add sed config https://gist.github.com/mdouchement/eb8684be330a09bebe66dbf91af16516

- [x] Add in `.vimrc`
    ```
    Plug 'fatih/vim-go', { 'for': 'go' }
    Plug 'dense-analysis/ale
    ```
- [x]  Add in `~/.vim/rcfiles/go.vim`
    ```
    " vim-go
    " ------
    
    let g:go_list_type = "quickfix"
    let g:go_fmt_command = "gofumpt"
    let g:go_fmt_fail_silently = 1
    
    let g:go_def_mode='gopls'
    let g:go_info_mode='gopls'
    
    let g:go_highlight_types = 1
    let g:go_highlight_fields = 1
    let g:go_highlight_functions = 1
    let g:go_highlight_methods = 1
    let g:go_highlight_operators = 1
    let g:go_highlight_build_constraints = 1
    let g:go_highlight_structs = 1
    let g:go_highlight_generate_tags = 1
    let g:go_highlight_space_tab_error = 0
    let g:go_highlight_array_whitespace_error = 0
    let g:go_highlight_trailing_whitespace_error = 0
    let g:go_highlight_extra_types = 1
    
    autocmd BufNewFile,BufRead *.go setlocal noexpandtab tabstop=4 shiftwidth=4 softtabstop=4
    
    augroup completion_preview_close
      autocmd!
      if v:version > 703 || v:version == 703 && has('patch598')
        autocmd CompleteDone * if !&previewwindow && &completeopt =~ 'preview' | silent! pclose | endif
      endif
    augroup END
    
    " ale
    let g:ale_linters = {} " TODO: should be done elsewhere if more linters to add
    :call extend(g:ale_linters, {
        \"go": ['gopls'], })
    ```